### PR TITLE
Added auto rotate for batch import, content manager, and front end upload

### DIFF
--- a/reason_4.0/lib/core/content_managers/image.php3
+++ b/reason_4.0/lib/core/content_managers/image.php3
@@ -93,6 +93,7 @@
 			'acceptable_types' => $acceptable_types) );
 			
 			$image = $this->get_element('image');
+			
 			$image->get_head_items($this->head_items);
 			$this->add_element('default_thumbnail', 'checkbox', 
 					array('description' => 'Generate thumbnail from full-size image'));


### PR DESCRIPTION
The content manager and front end uploads both use receive.php for handling uploads. Batch import uses a separate path, so I had to make changes to it separately. 

I'm using ImageMagick's -auto-orient flag, which rotates an image according to its EXIF Orientation flag, and then resets the flag to 1 (Normal orientation). Auto-orientation is only done on jpeg images that have an orientation flag.