### PR TITLE
avoid long timeouts on akismet sockets

### DIFF
--- a/akismet/Akismet.class.php
+++ b/akismet/Akismet.class.php
@@ -360,9 +360,10 @@ class SocketWriteRead implements AkismetRequestSender {
 		$response = '';
 
 		$fs = fsockopen($host, $port, $this->errorNumber, $this->errorString, 3);
+		stream_set_timeout($fs, 3); // Apply a read/write timeout, too
 
 		if($this->errorNumber != 0) {
-			throw new Exception('Error connecting to host: ' . $host . ' Error number: ' . $this->errorNumber . ' Error message: ' . $this->errorString);
+			throw new Exception('Akismet Error connecting to host: ' . $host . ' Error number: ' . $this->errorNumber . ' Error message: ' . $this->errorString);
 		}
 
 		if($fs !== false) {

--- a/disco/plugins/akismet/akismet.php
+++ b/disco/plugins/akismet/akismet.php
@@ -93,7 +93,15 @@ class AkismetFilter
 			$userip = get_user_ip_address();
 			$akismet->setUserIP($userip);
 
-			if ($akismet->isCommentSpam()) {
+			$is_spam = true; // Let Akismet tell us this isn't spam
+			try {
+				$is_spam = $akismet->isCommentSpam();
+			} catch (Exception $e) {
+				// Catch fatal Exceptions and reissue a non-fatal alert
+				trigger_error($e->getMessage());
+			}
+
+			if ($is_spam) {
 				$error_msg = 'Spam detected in this submission. If this message was made in error, please contact an administrator.';
 				$this->disco_form->set_error(NULL, $error_msg, false);
 			}

--- a/reason_4.0/lib/core/minisite_templates/modules/publication/forms/submit_comment.php
+++ b/reason_4.0/lib/core/minisite_templates/modules/publication/forms/submit_comment.php
@@ -244,9 +244,17 @@ class commentForm extends Disco
 			$akismet = new Akismet($url, $akismet_api_key);
 			$akismet->setCommentAuthor($this->get_value('author'));
 			$akismet->setCommentContent($this->get_value('comment_content'));
-			return ($akismet->isCommentSpam());
+
+			$is_spam = true; // Let Akismet tell us this isn't spam
+			try {
+				$is_spam = $akismet->isCommentSpam();
+			} catch (Exception $e) {
+				// Catch fatal Exceptions and reissue a non-fatal alert
+				trigger_error($e->getMessage());
+			}
+			return $is_spam;
 		}
-		return false;
+		return false; // If Akismet isn't present, let the comment through
 	}
 	
 	function post_show_form()


### PR DESCRIPTION
This is an attempt to terminate sockets to Akismet when Akismet is applying some type of rate limiting to our connections. There are many of questions (why does the library use sockets? why no php execution limit hit?), but this may allow the Akismet library to respond better under high-throughput conditions. 

A NewRelic trace of the issue during a flood of POST requests (akismet limits us):
<img width="1113" alt="screen shot 2017-04-05 at 2 11 20 pm" src="https://cloud.githubusercontent.com/assets/6674176/24722590/eaa37950-1a09-11e7-9374-ec4d2bd86ab8.png">
