### PR TITLE
Feature/form data module

### DIFF
--- a/reason_4.0/lib/core/minisite_templates/modules/form_data/markup/default.php
+++ b/reason_4.0/lib/core/minisite_templates/modules/form_data/markup/default.php
@@ -1,53 +1,226 @@
 <?php
-
+/**
+ * @package reason
+ * @subpackage modules
+ */
+ 
+/**
+ * Register markup class
+ */
 $GLOBALS['form_data_markups']['minisite_templates/modules/form_data/markup/default.php'] = 'DefaultFormDataMarkup';
 
+/**
+ * A base class for form data display markup
+ *
+ * Usage:
+ * 1. Extend this class
+ * 2. Redefine get_markup() method to produce the desired markup
+ * 3. Specify the path to the the extended class file in the page type, like:
+ *
+ * 'my_form_display' => array(
+ * 		'main_post' => array(
+ * 			'module' => 'form_data',
+ * 			'markup' => 'path/to/markup/class.php',
+ * 		),
+ * ),
+ *
+ * 4. Associate a form with the page, or specify it in the page type for a firmer connection
+ *
+ * Example get_markup() definition for a form with 'Your Name' and 'Your Major' as labels.
+ *
+ * function get_markup()
+ * {
+ * 	$ret = '<ul>';
+ * 	foreach($this->get_form_data() as $row)
+ * 	{
+ * 		$ret .= '<li>'.$this->get_label_value('Your Name', $row).': '.$this->get_label_value('Your Major', $row).'</li>';
+ * 	}
+ * 	return $ret;
+ * }
+ */
 class DefaultFormDataMarkup
 {
 	protected $form;
 	protected $form_data;
 	protected $label_map;
+	
+	/**
+	 * Set the form entity
+	 *
+	 * @param object $form
+	 * @return void
+	 */
 	function set_form($form)
 	{
 		$this->form = $form;
 	}
+	/**
+	 * Get the form entity
+	 * @return object
+	 */
+	function get_form()
+	{
+		return $this->form;
+	}
+	
+	/**
+	 * Overload this method to interact with the head items object
+	 *
+	 * Examples:
+	 * $head_items->add_stylesheet('/path/to/css.css');
+	 * $head_items->add_javascript('/path/to/js.js');
+	 *
+	 * @param object $head_items
+	 * @return void
+	 */
 	function add_head_items($head_items)
 	{
-		//
 	}
+	
+	/**
+	 * Set the form data
+	 *
+	 * @param array $form_data
+	 * @return void
+	 */
 	function set_form_data($form_data)
 	{
 		$this->form_data = $form_data;
 	}
+	
+	/**
+	 * Get the form data
+	 * @return array
+	 */
+	function get_form_data()
+	{
+		return $this->form_data;
+	}
+	
+	/**
+	 * Set the map of keys to labels
+	 *
+	 * @param array $label_map
+	 * @return void
+	 */
 	function set_label_map($label_map)
 	{
 		$this->label_map = $label_map;
 	}
+	
+	/**
+	 * Get the map of keys to labels
+	 *
+	 * @return array
+	 */
+	function get_label_map()
+	{
+		return $this->label_map;
+	}
+	
+	/**
+	 * Get the label for a given key
+	 *
+	 * @param string $key
+	 * @return string label or FALSE if label/key pair not found
+	 */
 	function get_label($key)
 	{
 		if(isset($this->label_map[$key]))
 		{
 			return $this->label_map[$key];
 		}
-		return NULL;
+		return FALSE;
 	}
+	
+	/**
+	 * Get the key for a given label
+	 *
+	 * @param string $label
+	 * @return mixed string key or FALSE if label/key pair not found
+	 */
 	function get_key($label)
 	{
 		return array_search($label, $this->label_map);
 	}
-	function get_label_value($label, $row)
+	
+	/**
+	 * Get the value for a given label for a given row
+	 *
+	 * Note that this method runs htmlspecialchars() on the return value by default.
+	 *
+	 * @param string $label
+	 * @param array $row
+	 * @param bool $htmlspecialchars
+	 * @return mixed string value or FALSE if label does not appear valid
+	 */
+	function get_label_value($label, $row, $htmlspecialchars = true)
 	{
 		if($key = $this->get_key($label))
 		{
-			return $row[$key];
+			return $htmlspecialchars ? htmlspecialchars($row[$key], ENT_QUOTES) : $row[$key];
+		}
+		trigger_error('Label "'.$label.'" not found.');
+		return false;
+	}
+	
+	/**
+	 * Produce an HTML formatted report on the structure of the form
+	 *
+	 * This can assist in debugging or in initial development of the form data display
+	 *
+	 * @return string HTML report
+	 */
+	function get_data_structure_report()
+	{
+		$ret = '';
+		$ret .= '<h3>Form Data Report</h3>';
+		$ret .= '<h4>Label Map</h4>';
+		$ret .= '<ul>';
+		$label_map = $this->get_label_map();
+		foreach($label_map as $key => $label)
+		{
+			$ret .= '<li><strong>'.htmlspecialchars($key).':</strong> '.htmlspecialchars($label).'</li>';
+		}
+		
+		$ret .= '</ul>';
+		$ret .= '<h4>Data Report</h4>';
+		$data = $this->get_form_data();
+		if(empty($data))
+		{
+			$ret .= '<p>No form data in database.</p>';
 		}
 		else
 		{
-			trigger_error('Label "'.$label.'" not found.');
+			$ret .= '<p>'.count($data).' rows in database.</p>';
+			$firstrow = reset($data);
+			$keys_without_labels = array();
+			foreach(array_keys($firstrow) as $key)
+			{
+				if(!isset($label_map[$key]))
+				{
+					$keys_without_labels[] = $key;
+				}
+			}
+			if(!empty($keys_without_labels))
+			{
+				$ret .= '<h5>Keys without labels</h5>';
+				$ret .= '<ul>';
+				foreach($keys_without_labels as $key)
+				{
+					$ret .= '<li>'.htmlspecialchars($key).'</li>';
+				}
+				$ret .= '</ul>';
+			}
 		}
+		return $ret;
 	}
+	/**
+	 * Get the markup
+	 * @return string HTML
+	 */
 	function get_markup()
 	{
-		return spray($this->form_data);
+		return $this->get_data_structure_report();
 	}
 }

--- a/reason_4.0/lib/core/minisite_templates/modules/form_data/markup/default.php
+++ b/reason_4.0/lib/core/minisite_templates/modules/form_data/markup/default.php
@@ -66,15 +66,20 @@ class DefaultFormDataMarkup
 	/**
 	 * Overload this method to interact with the head items object
 	 *
-	 * Examples:
-	 * $head_items->add_stylesheet('/path/to/css.css');
-	 * $head_items->add_javascript('/path/to/js.js');
+	 * Example implementation in a child class:
+	 *
+	 * function add_head_items($head_items)
+	 * {
+	 * 	$head_items->add_stylesheet('/path/to/css.css');
+	 * 	$head_items->add_javascript('/path/to/js.js');
+	 * }
 	 *
 	 * @param object $head_items
 	 * @return void
 	 */
 	function add_head_items($head_items)
 	{
+		// base class does nothing; overload this method to add head items
 	}
 	
 	/**
@@ -217,6 +222,19 @@ class DefaultFormDataMarkup
 	}
 	/**
 	 * Get the markup
+	 *
+	 * Example get_markup() definition for a form with 'Your Name' and 'Your Major' as labels.
+	 *
+	 * function get_markup()
+	 * {
+	 * 	$ret = '<ul>';
+	 * 	foreach($this->get_form_data() as $row)
+	 * 	{
+	 * 		$ret .= '<li>'.$this->get_label_value('Your Name', $row).': '.$this->get_label_value('Your Major', $row).'</li>';
+	 * 	}
+	 * 	return $ret;
+	 * }
+	 *
 	 * @return string HTML
 	 */
 	function get_markup()

--- a/reason_4.0/lib/core/minisite_templates/modules/form_data/markup/default.php
+++ b/reason_4.0/lib/core/minisite_templates/modules/form_data/markup/default.php
@@ -1,0 +1,53 @@
+<?php
+
+$GLOBALS['form_data_markups']['minisite_templates/modules/form_data/markup/default.php'] = 'DefaultFormDataMarkup';
+
+class DefaultFormDataMarkup
+{
+	protected $form;
+	protected $form_data;
+	protected $label_map;
+	function set_form($form)
+	{
+		$this->form = $form;
+	}
+	function add_head_items($head_items)
+	{
+		//
+	}
+	function set_form_data($form_data)
+	{
+		$this->form_data = $form_data;
+	}
+	function set_label_map($label_map)
+	{
+		$this->label_map = $label_map;
+	}
+	function get_label($key)
+	{
+		if(isset($this->label_map[$key]))
+		{
+			return $this->label_map[$key];
+		}
+		return NULL;
+	}
+	function get_key($label)
+	{
+		return array_search($label, $this->label_map);
+	}
+	function get_label_value($label, $row)
+	{
+		if($key = $this->get_key($label))
+		{
+			return $row[$key];
+		}
+		else
+		{
+			trigger_error('Label "'.$label.'" not found.');
+		}
+	}
+	function get_markup()
+	{
+		return spray($this->form_data);
+	}
+}

--- a/reason_4.0/lib/core/minisite_templates/modules/form_data/module.php
+++ b/reason_4.0/lib/core/minisite_templates/modules/form_data/module.php
@@ -1,0 +1,140 @@
+<?php
+$GLOBALS[ '_module_class_names' ][ basename( 'form_data', '.php' ) ] = 'FormDataModule';
+reason_include_once( 'minisite_templates/modules/default.php' );
+include_once(THOR_INC.'thor_viewer.php');
+
+/**
+ * @todo add ability to transform data before it is passed to the markup class
+ */
+class FormDataModule extends DefaultMinisiteModule
+{
+	var $acceptable_params = array(
+			'form' => '', //unique name or id
+			'markup' => 'minisite_templates/modules/form_data/markup/default.php',
+		);
+	var $form_entity;
+	var $markup_object;
+	function get_form_entity()
+	{
+		if(!isset($this->form_entity))
+		{
+			$this->form_entity = false;
+			if(!empty($this->params['form']))
+			{
+				if(is_numeric($this->params['form']))
+				{
+					if($form_id = (integer) $this->params['form'])
+					{
+						$form = new entity($form_id);
+						if($form->get_value('type') == id_of('form'))
+						{
+							$this->form_entity = $form;
+						}
+						else
+						{
+							trigger_error('Invalid form ID "'.$this->params['form'].'"');
+						}
+					}
+					else
+					{
+						trigger_error('Invalid form ID "'.$this->params['form'].'"');
+					}
+				}
+				else
+				{
+					if($form_id = id_of($this->params['form']))
+					{
+						$form = new entity($form_id);
+						if($form->get_value('type') == id_of('form'))
+						{
+							$this->form_entity = $form;
+						}
+						else
+						{
+							trigger_error('Unique name provided "'.$this->params['form'].'" not a form');
+						}
+					}
+					else
+					{
+						trigger_error('Invalid unique name "'.$this->params['form'].'"');
+					}
+				}
+			}
+			else
+			{
+				trigger_error('A form_id must be specified in the page type.');
+			}
+		}
+		return $this->form_entity;
+	}
+	function get_markup_object()
+	{
+		if(!isset($this->markup_object))
+		{
+			$this->markup_object = false;
+			if(!empty($this->params['markup']))
+			{
+				if(reason_file_exists($this->params['markup']))
+				{
+					reason_include_once($this->params['markup']);
+					if(!empty($GLOBALS['form_data_markups'][$this->params['markup']]))
+					{
+						$class = $GLOBALS['form_data_markups'][$this->params['markup']];
+						if(class_exists($class))
+						{
+							$this->markup_object = new $class;
+							$this->initalize_markup_object($this->markup_object);
+						}
+						else
+						{
+							trigger_error('Class '.$class.' not found');
+						}
+					}
+					else
+					{
+						trigger_error('Markup file does not register itself in $GLOBALS[\'form_data_markups\'][\''.$this->params['markup'].'\']');
+					}
+				}
+				else
+				{
+					trigger_error('No markup file exists at '.$this->params['markup']);
+				}
+			}
+			else
+			{
+				trigger_error('A markup path must be specified in the page type.');
+			}
+		}
+		return $this->markup_object;
+	}
+	function initalize_markup_object($markup_object)
+	{
+		$markup_object->set_form($this->get_form_entity());
+		
+	}
+	function init( $args = array() )
+	{	
+		parent::init( $args );
+		
+		if($markup_object = $this->get_markup_object())
+		{
+			if($form = $this->get_form_entity())
+			{
+				$thor = new ThorViewer();
+				$thor->init_thor_viewer($form->id());
+				$markup_object->set_form_data($thor->get_data());
+				$markup_object->set_label_map($thor->get_display_name_map());
+			}
+			$markup_object->add_head_items($this->get_head_items());
+		}			
+	}
+	function run()
+	{
+		echo '<div class="formDataModule">';
+		if($markup_object = $this->get_markup_object())
+		{
+			echo $markup_object->get_markup();
+		}
+		echo '</div>';
+	}
+}


### PR DESCRIPTION
This is a new module that aims to simplify the display of Thor form data on pages that are not the form submission page itself.

It is designed to allow developers to create a very terse markup class (no "real" examples included in this PR, though the inline documentation is designed to be fairly helpful).

I created this as underlying tech to support Carleton's "Carleton Faculty Stars" page.