### PR TITLE
Newsletters pull from same sites as event pages

### DIFF
--- a/reason_4.0/lib/core/classes/admin/modules/newsletter/SelectIncludes.php
+++ b/reason_4.0/lib/core/classes/admin/modules/newsletter/SelectIncludes.php
@@ -1,6 +1,5 @@
 <?php
 
-reason_include_once( 'classes/string_to_sites.php' );
 reason_include_once('classes/admin/modules/newsletter/additionalSiteFinder.php');
 /**
  * This file contains the SelectIncludes disco form step for use in the 
@@ -47,7 +46,7 @@ class SelectIncludes extends FormStep
 	function init($args=array())
 	{
 		parent::init($args);
-		
+
 		$site_id = (integer) $_REQUEST['site_id'];
 		$additional_site_finder = new additionalSiteFinder();
 		$additional_sites = $additional_site_finder->get_additional_sites($site_id);

--- a/reason_4.0/lib/core/classes/admin/modules/newsletter/SelectIncludes.php
+++ b/reason_4.0/lib/core/classes/admin/modules/newsletter/SelectIncludes.php
@@ -1,4 +1,7 @@
 <?php
+
+reason_include_once( 'classes/string_to_sites.php' );
+reason_include_once('classes/admin/modules/newsletter/additionalSiteFinder.php');
 /**
  * This file contains the SelectIncludes disco form step for use in the 
  * newsletter builder admin module. 
@@ -46,7 +49,15 @@ class SelectIncludes extends FormStep
 		parent::init($args);
 		
 		$site_id = (integer) $_REQUEST['site_id'];
-		
+		$additional_site_finder = new additionalSiteFinder();
+		$additional_sites = $additional_site_finder->get_additional_sites($site_id);
+		if ($additional_sites != array()) {
+			$site_id = array($site_id);
+			foreach ($additional_sites as $site) {
+				$site_id[] = $site->id();
+			}
+		}
+
 		// Only do this init if we're on the step that needs it.
 		if ($this->controller->get_current_step() != 'SelectIncludes')
 			return;
@@ -155,7 +166,7 @@ class SelectIncludes extends FormStep
 			$this->add_element('sucks_to_be_you', 'comment', array('text'=>'<h3>There are no publications or calendars associated with this site. Press continue if you would like to use the newsletter builder anyway.'));
 		
 	}
-	
+
 	function on_every_time()
 	{
 //		$this->controller->destroy_form_data();

--- a/reason_4.0/lib/core/classes/admin/modules/newsletter/SelectIncludes.php
+++ b/reason_4.0/lib/core/classes/admin/modules/newsletter/SelectIncludes.php
@@ -48,13 +48,15 @@ class SelectIncludes extends FormStep
 		parent::init($args);
 
 		$site_id = (integer) $_REQUEST['site_id'];
-		$additional_site_finder = new additionalSiteFinder();
+		$additional_site_finder = new eventsCalendarAdditionalSiteFinder();
 		$additional_sites = $additional_site_finder->get_additional_sites($site_id);
 		if ($additional_sites != array()) {
-			$site_id = array($site_id);
+			$es_param = array($site_id);
 			foreach ($additional_sites as $site) {
-				$site_id[] = $site->id();
+				$es_param[] = $site->id();
 			}
+		} else {
+			$es_param = $site_id;
 		}
 
 		// Only do this init if we're on the step that needs it.
@@ -64,7 +66,7 @@ class SelectIncludes extends FormStep
 		//////////////// PUBLICATIONS /////////////////
 		// Select all publications that are attached to this site.
 		$pub_factory = new PubHelperFactory();
-		$es = new entity_selector($site_id);
+		$es = new entity_selector($es_param);
 		$es->add_type(id_of('publication_type'));
 		// Add the page_id to which the pub belongs (so we can get url)
 		$es->add_right_relationship_field('page_to_publication', 'entity', 'id', 'page_id');
@@ -142,7 +144,7 @@ class SelectIncludes extends FormStep
 		$cal->run();
 		$events = $cal->get_all_events(); */
 		
-		$es = new entity_selector($site_id);
+		$es = new entity_selector($es_param);
 		$es->add_type(id_of('event_type'));
 		$es->set_num(1);
 		$es->limit_tables();

--- a/reason_4.0/lib/core/classes/admin/modules/newsletter/SelectItems.php
+++ b/reason_4.0/lib/core/classes/admin/modules/newsletter/SelectItems.php
@@ -117,7 +117,9 @@ class SelectItems extends FormStep
 		if ($this->controller->get_form_data('events_start_date') != '')
 		{
 			$site_id = (integer) $_REQUEST['site_id'];
-			$site = new entity($site_id);
+			$additional_site_finder = new additionalSiteFinder();
+			$site = $additional_site_finder->get_additional_sites($site_id);
+			$site[] = new entity($site_id);
 			$start_date = $this->controller->get_form_data('events_start_date');
 			$end_date = $this->controller->get_form_data('events_end_date');
 			$end_date = (!empty($end_date)) ? $end_date : date('Y-m-d');

--- a/reason_4.0/lib/core/classes/admin/modules/newsletter/SelectItems.php
+++ b/reason_4.0/lib/core/classes/admin/modules/newsletter/SelectItems.php
@@ -119,13 +119,13 @@ class SelectItems extends FormStep
 		if ($this->controller->get_form_data('events_start_date') != '')
 		{
 			$site_id = (integer) $_REQUEST['site_id'];
-			$additional_site_finder = new additionalSiteFinder();
-			$site = $additional_site_finder->get_additional_sites($site_id);
-			$site[] = new entity($site_id);
+			$additional_site_finder = new eventsCalendarAdditionalSiteFinder();
+			$sites = $additional_site_finder->get_additional_sites($site_id);
+			$sites[] = new entity($site_id);
 			$start_date = $this->controller->get_form_data('events_start_date');
 			$end_date = $this->controller->get_form_data('events_end_date');
 			$end_date = (!empty($end_date)) ? $end_date : date('Y-m-d');
-			$cal = new reasonCalendar(array('site'=>$site,'start_date'=>$start_date,'end_date'=>$end_date));
+			$cal = new reasonCalendar(array('site'=>$sites,'start_date'=>$start_date,'end_date'=>$end_date));
 			$cal->run();
 			$events = $cal->get_all_events();
 			$days = $cal->get_all_days();

--- a/reason_4.0/lib/core/classes/admin/modules/newsletter/SelectItems.php
+++ b/reason_4.0/lib/core/classes/admin/modules/newsletter/SelectItems.php
@@ -1,4 +1,6 @@
 <?php
+
+reason_include_once('classes/admin/modules/newsletter/additionalSiteFinder.php');
 /**
  * This file contains the SelectItems disco multi-step form step for
  * NewsletterModule and a plasmature type used in the creation of a

--- a/reason_4.0/lib/core/classes/admin/modules/newsletter/additionalSiteFinder.php
+++ b/reason_4.0/lib/core/classes/admin/modules/newsletter/additionalSiteFinder.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * Class additionalSiteFinder
+ * Gets additional sites from which to draw events and publications for a newsletter
+ *
+ * @author Adante Ratzlaff
+ */
+class additionalSiteFinder
+{
+	/**
+	 * If the current site has an events module and the page type of the events module has the additional_sites param,
+	 * pull events and publications from all additional sites.
+	 * @param $site_id
+	 * @return int|array Single site id or list of site ids
+	 */
+	function get_additional_sites($site_id){
+		$es = new entity_selector($site_id);
+		$es->add_type(id_of('minisite_page'));
+		$site_pages = $es->run_one();
+		$page_types = array();
+		foreach($site_pages as $page) {
+			$page_type = $page->get_value('custom_page');
+			$page_types[] = $page_type;
+		}
+		$reason_page_types =& get_reason_page_types();
+		$additional_sites = '';
+		foreach($page_types as $page_type_name) {
+			$page_type = $reason_page_types->get_page_type($page_type_name);
+			if($regions = $page_type->module_regions('events')) {
+				$region = $page_type->get_region(reset($regions));
+				if(isset($region['module_params'])){
+					$module_params = $region['module_params'];
+					if(isset($module_params['additional_sites'])) {
+						$additional_sites .= $module_params['additional_sites'];
+					}
+				}
+			}
+		}
+		$string_to_sites = new stringToSites();
+		$sites = $string_to_sites->get_sites_from_string($additional_sites);
+		return $sites;
+	}
+}

--- a/reason_4.0/lib/core/classes/admin/modules/newsletter/additionalSiteFinder.php
+++ b/reason_4.0/lib/core/classes/admin/modules/newsletter/additionalSiteFinder.php
@@ -1,5 +1,8 @@
 <?php
 
+reason_include_once( 'classes/string_to_sites.php' );
+reason_include_once('classes/event_helper.php');
+
 /**
  * Class additionalSiteFinder
  * Gets additional sites from which to draw events and publications for a newsletter
@@ -12,31 +15,49 @@ class additionalSiteFinder
 	 * If the current site has an events module and the page type of the events module has the additional_sites param,
 	 * pull events and publications from all additional sites.
 	 * @param $site_id
-	 * @return int|array Single site id or list of site ids
+	 * @return entity|array Single site entity or array of site entities
 	 */
 	function get_additional_sites($site_id){
-		$es = new entity_selector($site_id);
-		$es->add_type(id_of('minisite_page'));
-		$site_pages = $es->run_one();
+		// Retrieve an array of all possible events pages on the site
+		$event_helper = new EventHelper();
+		$ps = new entity_selector($site_id);
+		$ps->add_type( id_of('minisite_page') );
+		$rels = array();
+		foreach($event_helper->get_events_page_types() as $page_type)
+		{
+			$rels[] = 'page_node.custom_page = "'.$page_type.'"';
+		}
+		$ps->add_relation('( '.implode(' OR ', $rels).' )');
+		$site_pages = $ps->run_one();
+
+		// Get the subset of events page types used by this site's events pages
 		$page_types = array();
 		foreach($site_pages as $page) {
 			$page_type = $page->get_value('custom_page');
 			$page_types[] = $page_type;
 		}
 		$reason_page_types =& get_reason_page_types();
+
+		// For each events page type used by the site, check to see if the page type has the module parameter
+		// 'additional_sites' set.  If so, add the string of sites to a longer site string.
 		$additional_sites = '';
 		foreach($page_types as $page_type_name) {
 			$page_type = $reason_page_types->get_page_type($page_type_name);
-			if($regions = $page_type->module_regions('events')) {
-				$region = $page_type->get_region(reset($regions));
-				if(isset($region['module_params'])){
-					$module_params = $region['module_params'];
-					if(isset($module_params['additional_sites'])) {
-						$additional_sites .= $module_params['additional_sites'];
+			foreach ($event_helper->get_events_modules() as $module) {
+				if($regions = $page_type->module_regions($module)) {
+					$region = $page_type->get_region(reset($regions));
+					if(isset($region['module_params'])){
+						$module_params = $region['module_params'];
+						if(isset($module_params['additional_sites'])) {
+							$additional_sites .= $module_params['additional_sites'];
+						}
 					}
+					break;
 				}
 			}
 		}
+
+		// Convert the string to a list of site entities.
 		$string_to_sites = new stringToSites();
 		$sites = $string_to_sites->get_sites_from_string($additional_sites);
 		return $sites;

--- a/reason_4.0/lib/core/classes/admin/modules/newsletter/eventsCalendarAdditionalSiteFinder.php
+++ b/reason_4.0/lib/core/classes/admin/modules/newsletter/eventsCalendarAdditionalSiteFinder.php
@@ -9,13 +9,13 @@ reason_include_once('classes/event_helper.php');
  *
  * @author Adante Ratzlaff
  */
-class additionalSiteFinder
+class eventsCalendarAdditionalSiteFinder
 {
 	/**
 	 * If the current site has an events module and the page type of the events module has the additional_sites param,
 	 * pull events and publications from all additional sites.
 	 * @param $site_id
-	 * @return entity|array Single site entity or array of site entities
+	 * @return int|array Single site id or array of site ids
 	 */
 	function get_additional_sites($site_id){
 		// Retrieve an array of all possible events pages on the site


### PR DESCRIPTION
Newsletters now draw events and publications from multiple sites if their parent site has one or more modified event page types that pull events from other sites via the "additional_sites" parameter.