### PR TITLE
Bugfix/thor default field sizes and option value injection

### DIFF
--- a/thor/thor.php
+++ b/thor/thor.php
@@ -238,8 +238,8 @@ class ThorCore
 						// Inject options if data reflects new options
 						if (property_exists($kEl, 'options'))
 							if (!in_array($kEl->value, $kEl->options))
-								$kEl->options[$kEl->value] = $kEl->value;
-					}
+							$kEl->options[$kEl->value] = $kEl->value;
+						}
 					elseif (isset($display_values[$k]['group_id']))
 					{
 						$group[$display_values[$k]['group_id']][] = $v;
@@ -993,12 +993,12 @@ class ThorCore
 				$db_structure[$node->tagAttrs['id']]['type'] = 'text';
 			}
 			elseif (($node->tagName == 'radiogroup') || ($node->tagName == 'optiongroup')) {
-				$db_structure[$node->tagAttrs['id']]['type'] = 'tinytext';
+				$db_structure[$node->tagAttrs['id']]['type'] = 'text';
 			}
 			elseif ($node->tagName == 'checkboxgroup') {
 				$node_children = $node->tagChildren;
 				foreach ($node_children as $node2) {
-					$db_structure[$node2->tagAttrs['id']]['type'] = 'tinytext';
+					$db_structure[$node2->tagAttrs['id']]['type'] = 'text';
 				}
 			}
 			elseif ($node->tagName == 'upload') {

--- a/thor/thor.php
+++ b/thor/thor.php
@@ -236,7 +236,7 @@ class ThorCore
 						}
 						$disco_obj->set_value($k, $v);
 						// Inject options if data reflects new options
-						if (property_exists($kEl, 'options') && $kEl->value != '' && !in_array($kEl->value, $kEl->options))
+						if (property_exists($kEl, 'options') && strlen($kEl->value) != 0 && !in_array($kEl->value, $kEl->options))
 						{
 							$kEl->options[$kEl->value] = $kEl->value;
 						}

--- a/thor/thor.php
+++ b/thor/thor.php
@@ -236,10 +236,11 @@ class ThorCore
 						}
 						$disco_obj->set_value($k, $v);
 						// Inject options if data reflects new options
-						if (property_exists($kEl, 'options'))
-							if (!in_array($kEl->value, $kEl->options))
+						if (property_exists($kEl, 'options') && $kEl->value != '' && !in_array($kEl->value, $kEl->options))
+						{
 							$kEl->options[$kEl->value] = $kEl->value;
 						}
+					}
 					elseif (isset($display_values[$k]['group_id']))
 					{
 						$group[$display_values[$k]['group_id']][] = $v;


### PR DESCRIPTION
I encountered a couple bugs as I am working on IRB updates. I believe these are a result of the change from ENUM to TEXT fields.

The more "buggy" bug creates blank options (selected radio buttons with no label) when a form is reloaded - thor interprets the empty string in the DB as a new option and adds it to the form.

The other change is to accommodate longer option text for radio and checkbox labels. In the IRB, several radio groups use long text to fully describe the reasoning behind each option. I've changed the field from TINYTEXT to TEXT.

Both are edits to thor.php