### PR TITLE
Event result limit

### DIFF
--- a/reason_4.0/lib/core/classes/entity_selector.php
+++ b/reason_4.0/lib/core/classes/entity_selector.php
@@ -232,14 +232,43 @@
 		 * have statements in add_relation that don't use fully qualified entity_table.field_name pairs.
 		 */
 		var $_exclude_tables_dynamically = false;
+		 
+		var $union = false;
+		
+		/**
+		 * Set a limit on entities returned, enforced in php.
+		 *
+		 * This is useful for when you are doing outer joins (e.g. enable multivalue results)
+		 * and you want to precisely set your limit. This is different from $num in that
+		 * the full SQL query is performed and this limit is enforced as results are
+		 * retrievied in php.
+		 *
+		 * Set using set_entity_limit(); get using get_entity_limit().
+		 *
+		 * @access protected
+		 * @var integer
+		 */
+		protected $entity_limit = -1;
+		
+		/**
+		 * Do we need to have all multivalued fields when an entity limit is applied?
+		 *
+		 * True gives you "perfect" results where each entity is fully populated with
+		 * multivalued fields. This may be slower and/or more memory consuming because
+		 * the entity selector still needs to grab each row from the database.
+		 *
+		 * False puts the entity selector into a mode where it stps fetching results once
+		 * it has fetched a certain number of entities. Some entities may not have every
+		 * multivalued field fully populated.
+		 *
+		 * @var boolean
+		 */
+		protected $entity_limit_full_multivalued_fields = true;
 				
 		/**
  		 * Constructor 
 		 * @param int $site_id optional site id, if set will only select entities belonging to the given site
 		 */
-		 
-		var $union = false;
-		
 		function entity_selector($site_id = false) // {{{
 		{
 			$this->query = '';
@@ -1107,11 +1136,17 @@
 			}
 			$query = $this->get_one_query( $type , $status);
 			$factory =& $this->get_entity_factory();
+			$entity_limit = $this->get_entity_limit();
 			if($this->cache_lifespan)
 			{
 				$factory_class = ($factory) ? get_class($factory) : '';
 				//echo '<p>caching '.$this->cache_lifespan.' secs</p>';
-				$cache = new ObjectCache('entity_selector_cache_'.get_current_db_connection_name().'_'.$this->_enable_multivalue_results.'_'.$factory_class.'_'.$query, $this->cache_lifespan);
+				$cache_key = 'entity_selector_cache_'.get_current_db_connection_name().'_'.$this->_enable_multivalue_results.'_'.$factory_class.'_'.$query;
+				if($entity_limit > 0)
+				{
+					$cache_key .= '_entitylimit=' . $entity_limit;
+				}
+				$cache = new ObjectCache($cache_key, $this->cache_lifespan);
 				$results =& $cache->fetch();
 				if(false !== $results)
 				{
@@ -1130,6 +1165,7 @@
 			$r = db_query( $query , $this->description.': '.$error );
 			
 			if ($printQuery) { echo "Got back [" . mysql_num_rows($r) . "] ROWS...<P>"; }
+			$num_results = 0;
 			while( $row = mysql_fetch_array( $r, MYSQL_ASSOC ) )
 			{
 				//pray ($row);
@@ -1169,6 +1205,18 @@
 					$e->_values = $row;
 				}
 				$e->full_fetch_performed($fetching_all_fields);
+				if(!isset($results[ $row[ 'id' ] ]))
+				{
+					if($entity_limit > 0 && $num_results >= $entity_limit)
+					{
+						if(!$this->entity_limit_full_multivalued_fields)
+						{
+							break;
+						}
+						continue;
+					}
+					$num_results++;
+				}
 				$results[ $row[ 'id' ] ] = $e;
 			}
 			mysql_free_result( $r );
@@ -1738,6 +1786,15 @@
 		{
 			if (!isset($this->entity_factory_class)) $this->entity_factory_class = false;
 			return $this->entity_factory_class;
+		}
+		
+		function set_entity_limit($num, $full_multivalued_fields = true) {
+			$this->entity_limit = (integer) $num;
+			$this->entity_limit_full_multivalued_fields = (boolean) $full_multivalued_fields;
+		}
+		
+		function get_entity_limit() {
+			return $this->entity_limit;
 		}
 	} // }}}
 ?>

--- a/reason_4.0/lib/core/classes/entity_selector.php
+++ b/reason_4.0/lib/core/classes/entity_selector.php
@@ -245,7 +245,6 @@
 		 *
 		 * Set using set_entity_limit(); get using get_entity_limit().
 		 *
-		 * @access protected
 		 * @var integer
 		 */
 		protected $entity_limit = -1;

--- a/reason_4.0/lib/core/minisite_templates/modules/events.php
+++ b/reason_4.0/lib/core/minisite_templates/modules/events.php
@@ -1377,6 +1377,20 @@ class EventsModule extends DefaultMinisiteModule
 		$this->show_focus();
 		return ob_get_clean();
 	}
+	
+	function get_section_markup_notice()
+	{
+		$ret = '';
+		
+		if( $cal = $this->get_current_calendar() )
+		{
+			if( $cal->limit_reached() )
+			{
+				$ret .= '<div class="notice"><h3>Not Showing All Events For This Time Period</h3><p>This calendar can only show ' . number_format( $cal->get_limit() ) . ' events at a time. Because the currently selected view contains more events than that, there are some events that are not shown below. Please try choosing a shorter timespan (e.g. day/week/month).</p></div>';
+			}
+		}
+		return $ret;
+	}
 	/**
 	 * Get the ical links section markup
 	 * @return string
@@ -1483,6 +1497,7 @@ class EventsModule extends DefaultMinisiteModule
 				$bundle->set_function('options_markup', array($this, 'get_section_markup_options'));
 				$bundle->set_function('navigation_markup', array($this, 'get_section_markup_navigation'));
 				$bundle->set_function('focus_markup', array($this, 'get_section_markup_focus'));
+				$bundle->set_function('notice_markup', array($this, 'get_section_markup_notice'));
 				$bundle->set_function('list_title_markup', array($this, 'get_section_markup_list_title'));
 				$bundle->set_function('ical_links_markup', array($this, 'get_section_markup_ical_links'));
 				$bundle->set_function('rss_links_markup', array($this, 'get_section_markup_rss_links'));

--- a/reason_4.0/lib/core/minisite_templates/modules/events_markup/archive/archive_events_list_chrome.php
+++ b/reason_4.0/lib/core/minisite_templates/modules/events_markup/archive/archive_events_list_chrome.php
@@ -83,6 +83,7 @@ class archiveEventsListChromeMarkup implements eventsListChromeMarkup
 		
 		$ret .= $this->get_section_markup('focus');
 		$ret .= $this->get_section_markup('list_title');
+		$ret .= $this->get_section_markup('notice');
 		
 		$ret .= $this->get_section_markup('list');
 		

--- a/reason_4.0/lib/core/minisite_templates/modules/events_markup/default/events_list_chrome.php
+++ b/reason_4.0/lib/core/minisite_templates/modules/events_markup/default/events_list_chrome.php
@@ -88,6 +88,7 @@ class defaultEventsListChromeMarkup implements eventsListChromeMarkup
 		
 		$ret .= $this->get_section_markup('focus');
 		$ret .= $this->get_section_markup('list_title');
+		$ret .= $this->get_section_markup('notice');
 		
 		$ret .= $this->get_section_markup('list');
 		

--- a/reason_4.0/lib/core/minisite_templates/modules/events_markup/hybrid/hybrid_events_list_chrome.php
+++ b/reason_4.0/lib/core/minisite_templates/modules/events_markup/hybrid/hybrid_events_list_chrome.php
@@ -84,6 +84,7 @@ class hybridEventsListChromeMarkup implements eventsListChromeMarkup
 		
 		$ret .= $this->get_section_markup('focus');
 		$ret .= $this->get_section_markup('list_title');
+		$ret .= $this->get_section_markup('notice');
 		
 		$ret .= $this->get_section_markup('list');
 		

--- a/reason_4.0/lib/core/minisite_templates/modules/events_markup/mini/mini_events_list_chrome.php
+++ b/reason_4.0/lib/core/minisite_templates/modules/events_markup/mini/mini_events_list_chrome.php
@@ -74,6 +74,7 @@ class miniEventsListChromeMarkup implements eventsListChromeMarkup
 	{
 		$ret = '';
 		$ret .= $this->get_section_markup('list_title');
+		$ret .= $this->get_section_markup('notice');
 		
 		$ret .= $this->get_section_markup('list');
 		

--- a/reason_4.0/lib/core/minisite_templates/modules/events_markup/responsive/responsive_archive_list_chrome.php
+++ b/reason_4.0/lib/core/minisite_templates/modules/events_markup/responsive/responsive_archive_list_chrome.php
@@ -84,6 +84,7 @@ class responsiveArchiveEventsListChromeMarkup implements eventsListChromeMarkup
 		
 		$ret .= $this->get_section_markup('focus');
 		$ret .= $this->get_section_markup('list_title');
+		$ret .= $this->get_section_markup('notice');
 		
 		$ret .= $this->get_section_markup('list');
 		

--- a/reason_4.0/lib/core/minisite_templates/modules/events_markup/responsive/responsive_hybrid_list_chrome.php
+++ b/reason_4.0/lib/core/minisite_templates/modules/events_markup/responsive/responsive_hybrid_list_chrome.php
@@ -84,6 +84,7 @@ class responsiveHybridEventsListChromeMarkup implements eventsListChromeMarkup
 		
 		$ret .= $this->get_section_markup('focus');
 		$ret .= $this->get_section_markup('list_title');
+		$ret .= $this->get_section_markup('notice');
 		
 		$ret .= $this->get_section_markup('list');
 		

--- a/reason_4.0/lib/core/minisite_templates/modules/events_markup/responsive/responsive_list_chrome.php
+++ b/reason_4.0/lib/core/minisite_templates/modules/events_markup/responsive/responsive_list_chrome.php
@@ -84,6 +84,7 @@ class responsiveEventsListChromeMarkup implements eventsListChromeMarkup
 		
 		$ret .= $this->get_section_markup('focus');
 		$ret .= $this->get_section_markup('list_title');
+		$ret .= $this->get_section_markup('notice');
 		
 		$ret .= $this->get_section_markup('list');
 		$ret .= '</div>'."\n";

--- a/reason_4.0/lib/core/minisite_templates/modules/events_markup/tickets/tickets_events_list_chrome.php
+++ b/reason_4.0/lib/core/minisite_templates/modules/events_markup/tickets/tickets_events_list_chrome.php
@@ -9,6 +9,7 @@ class ticketsEventListChrome extends miniEventsListChromeMarkup
 	public function get_markup()
 	{
 		$ret = '';
+		$ret .= $this->get_section_markup('notice');
 		$ret .= $this->get_section_markup('list');
 		return $ret;
 	}


### PR DESCRIPTION
This change sets a cap on the maximum number of events that can be fetched on a given calendar list.

This also adds a notice to html calendar listings when a view is truncated so users are aware that they are seeing a list that does not include full results.

This adds a new function: `entity_selector::set_entity_limit()`, which is a php-enforced limit on number of entities retrieved. The mysql-enforced `entity_selector::set_num()` does not work for this purpose because it limits based on rows. In an outer join situation where a single entity can be represented by multiple rows, `set_num` is inaccurate.