### PR TITLE
load left relationships in sort order

### DIFF
--- a/reason_4.0/lib/core/classes/entity.php
+++ b/reason_4.0/lib/core/classes/entity.php
@@ -568,6 +568,7 @@ class entity
 		{
 			$dbq->add_relation( '(r.site=0 OR r.site=' . (integer) $this->_env['site'] . ')' );
 		}
+		$dbq->set_order( 'rel_sort_order' );
 		$rels = $dbq->run( 'Unable to grab relationships' );
 		foreach( $rels as $r)
 		{


### PR DESCRIPTION
Tweak an SQL query occurring during `$entity->get_left_relationships()` so the relationships are returned are in sort order.

This fixes a Sidebar image sorting issue in WordPress: migrated sidebar images were out of order. It's easier to fix the sorting during an export, rather than during import.
 
There's already a similar sort constraint in the `_init_right_relationships` method. I don't know if no sort order in _init_left_relationships was accidental or intentional.

@mryand tagging you for thoughts here. I couldn't find any regressions or negatively affected code.