### PR TITLE
Refactor XML export generator

### DIFF
--- a/reason_4.0/lib/core/classes/xml_export.php
+++ b/reason_4.0/lib/core/classes/xml_export.php
@@ -167,14 +167,14 @@ class ExportXMLWriter extends XMLWriter
 			if (is_numeric($v)) {
 				$this->text($v);
 			} else {
-				$entitied = htmlentities($v, ENT_QUOTES, 'utf-8');
-				$this->writeCdata($entitied);
+				// Convert to UTF-8, if needed
+				$detected = mb_detect_encoding($v, 'UTF-8, ISO-8859-1', true);
+				if ($detected) {
+					$v = mb_convert_encoding($v, 'UTF-8', $detected);
+				}
+				$this->text($v);
 			}
 		}
-	}
-
-	public function addCdataText($value) {
-		$this->writeCdata($value);
 	}
 
 	public function formatAndFinish($site, $type)
@@ -189,7 +189,7 @@ class ExportXMLWriter extends XMLWriter
 		if ($dom->loadXML($string)) {
 			return $dom->saveXML();
 		} else {
-			throw new Exception("Couldn not format XML for type '{$type}' in site '{$site}'");
+			throw new Exception("Could not format XML for type '{$type}' in site '{$site}'");
 		}
 	}
 }

--- a/reason_4.0/lib/core/classes/xml_export.php
+++ b/reason_4.0/lib/core/classes/xml_export.php
@@ -172,6 +172,11 @@ class ExportXMLWriter extends XMLWriter
 				if ($detected) {
 					$v = mb_convert_encoding($v, 'UTF-8', $detected);
 				}
+				// XmlWriter::text encodes some number of characters to ensure valid XML
+				// It's not exactly the same as this:
+				// $this->writeRaw(htmlspecialchars($v, ENT_QUOTES | ENT_XML1, 'UTF-8'));
+				// but it's close: see comments https://www.php.net/manual/en/function.xmlwriter-text.php
+				// and appears to sufficiently encode html chatacters 
 				$this->text($v);
 			}
 		}
@@ -182,6 +187,10 @@ class ExportXMLWriter extends XMLWriter
 		$this->endDocument();
 		$string = $this->outputMemory();
 
+		// Validate and format the output.
+		// Note: this seems to decode certain entities (like &quot; goes back to ")
+		// The impact of the decoding is unclear, as returned XML is still valid
+		// and HTML decoding a value produces valid html (AFAICT)
 		$dom = new DOMDocument('1.0', 'UTF-8');
 		$dom->preserveWhiteSpace = false;
 		$dom->formatOutput = true;

--- a/reason_4.0/lib/core/classes/xml_export.php
+++ b/reason_4.0/lib/core/classes/xml_export.php
@@ -144,6 +144,56 @@ class reason_xml_export_generator
 	}
 }
 
+class ExportXMLWriter extends XMLWriter
+{
+	public function startElementWithAttrs($name, $attributes)
+	{
+		$this->startElement($name);
+		foreach ($attributes as $k => $v) {
+			$this->addAttribute($k, $v);
+		}
+	}
+
+	public function addAttribute($key, $val)
+	{
+		$this->startAttribute($key);
+		$this->text($val);
+		$this->endAttribute();
+	}
+
+	public function addTextSafe($v)
+	{
+		if ($v) {
+			if (is_numeric($v)) {
+				$this->text($v);
+			} else {
+				$entitied = htmlentities($v, ENT_QUOTES, 'utf-8');
+				$this->writeCdata($entitied);
+			}
+		}
+	}
+
+	public function addCdataText($value) {
+		$this->writeCdata($value);
+	}
+
+	public function formatAndFinish($site, $type)
+	{
+		$this->endDocument();
+		$string = $this->outputMemory();
+
+		$dom = new DOMDocument('1.0', 'UTF-8');
+		$dom->preserveWhiteSpace = false;
+		$dom->formatOutput = true;
+
+		if ($dom->loadXML($string)) {
+			return $dom->saveXML();
+		} else {
+			throw new Exception("Couldn not format XML for type '{$type}' in site '{$site}'");
+		}
+	}
+}
+
 /**
  * A class that generates the 0.1 version of the Reason XML export data format
  */
@@ -157,99 +207,120 @@ class reason_xml_export_generator_version_point_one extends reason_xml_export_ge
 	 */
 	function get_xml($entities)
 	{
-		$lines[] = '<'.'?'.'xml version="1.0" encoding="utf-8"'.'?'.'>';
-		$lines[] = '<reason_data version="0.1" from="http://'.REASON_HOST.'/">';
-		foreach($entities as $e)
-		{
+		$xml = new ExportXMLWriter();
+		$xml->openMemory();
+		$xml->startDocument("1.0", 'utf-8');
+
+		$xml->startElementWithAttrs('reason_data', [
+			'version' => '0.1',
+			'from' => 'http://' . REASON_HOST . '/',
+		]);
+
+		foreach ($entities as $e) {
 			$type = new entity($e->get_value('type'));
 			$site = $e->get_owner();
-			$line = "\t".'<entity id="'.$e->id().'"';
-			$line .= ' type="'.$type->get_value('unique_name').'" ';
-			$line .= ' site="'.$site->get_value('unique_name').'"';
-			if($e->get_value('unique_name'))
-			{
-				$line .= ' unique_name="'.$e->get_value('unique_name').'"';
+
+			$xml->startElementWithAttrs('entity', [
+				'id' => $e->id(),
+				'type' => $type->get_value('unique_name'),
+				'site' => $site->get_value('unique_name'),
+			]);
+			if ($e->get_value('unique_name')) {
+				$xml->addAttribute('unique_name', $e->get_value('unique_name'));
 			}
-			$line .= '>';
-			$lines[] = $line;
-			foreach ($e->get_values() as $k=>$v)
-			{
-				$lines[] = "\t\t".'<value name="'.$k.'">'.htmlspecialchars($v).'</value>';
-				if ( in_array($k, [ 'created_by', 'last_edited_by' ] ) ) {
+
+			foreach ($e->get_values() as $k => $v) {
+				$xml->startElementWithAttrs('value', [
+					'name' => $k,
+				]);
+				$xml->addTextSafe($v);
+				$xml->endElement();
+
+				if (in_array($k, ['created_by', 'last_edited_by'])) {
 					$username = $this->get_reason_username($v);
-					$lines[] = "\t\t" . '<value name="' .$k. '_username">' . htmlspecialchars( $username ) . '</value>';
+					$xml->startElementWithAttrs('value', [
+						'name' => $k . '_username',
+					]);
+					$xml->addTextSafe($username);
+					$xml->endElement();
 				}
 			}
-			if ($e->method_supported('get_export_generated_data'))
-			{
+
+			if ($e->method_supported('get_export_generated_data')) {
 				$data = $e->get_export_generated_data();
-				if(!empty($data))
-				{
-					foreach($data as $k => $v)
-					{
-						$lines[] = "\t\t".'<value name="_generated_'.$k.'" type="computed">'.htmlspecialchars($v).'</value>';
+				if (!empty($data)) {
+					foreach ($data as $k => $v) {
+						$xml->startElementWithAttrs('value', [
+							'name' => '_generated_' . $k,
+							'type' => 'computed',
+						]);
+						$xml->addTextSafe($v);
+						$xml->endElement();
 					}
 				}
 			}
-			$method = '_get_custom_values_for_'.$type->get_value('unique_name');
-			if(method_exists($this, $method) )
-			{
-				$lines = array_merge($lines, $this->$method($e, "\t\t") );
-			}
-			$lines[] = "\t\t".'<relationships>';
-			$left_rel_info = $e->get_left_relationships_info();
-			foreach($e->get_left_relationships() as $alrel_id=>$rels)
-			{
-				if(is_numeric($alrel_id) && !empty($rels))
-				{
-					$lines = array_merge($lines, $this->_get_rel_xml_lines($rels, $left_rel_info[$alrel_id], $alrel_id, 'left', "\t\t\t") );
-				}
-			}
-			$right_rel_info = $e->get_right_relationships_info();
-			foreach($e->get_right_relationships() as $alrel_id=>$rels)
-			{
-				if(is_numeric($alrel_id) && !empty($rels))
-				{
 
-					$lines = array_merge($lines, $this->_get_rel_xml_lines($rels, $right_rel_info[$alrel_id], $alrel_id, 'right', "\t\t\t") );
+			$xml->startElement('relationships');
+
+			$left_rel_info = $e->get_left_relationships_info();
+			foreach ($e->get_left_relationships() as $alrel_id => $rels) {
+				if (is_numeric($alrel_id) && !empty($rels)) {
+					$this->_get_rel_xml_lines($xml, $rels, $left_rel_info[$alrel_id], $alrel_id, 'left');
 				}
 			}
-			$lines[] = "\t\t".'</relationships>';
-			$lines[] = "\t".'</entity>';
+
+			$right_rel_info = $e->get_right_relationships_info();
+			foreach ($e->get_right_relationships() as $alrel_id => $rels) {
+				if (is_numeric($alrel_id) && !empty($rels)) {
+					$this->_get_rel_xml_lines($xml, $rels, $right_rel_info[$alrel_id], $alrel_id, 'right');
+				}
+			}
+
+			$xml->endElement(); //relationships
+			$xml->endElement(); //entity
 		}
-		$lines[] = "</reason_data>";
-		return implode("\n",$lines);
+		$xml->endElement(); //reason_data
+
+		return $xml->formatAndFinish($site->get_value('unique_name'), $type->get_value('unique_name'));
 	}
 
 	/**
 	 * @access private
+	 * @param ExportXMLWriter $xw
 	 * @param array $rels
 	 * @param array $rels_info
 	 * @param integer $alrel_id
 	 * @param string $dir
-	 * @param string $indent
-	 * @return array lines
 	 */
-	function _get_rel_xml_lines($rels, $rels_info, $alrel_id, $dir, $indent)
+	function _get_rel_xml_lines(ExportXMLWriter &$xw, $rels, $rels_info, $alrel_id, $dir)
 	{
-		$lines = array();
-		$lines[] = $indent.'<alrel name="'.relationship_name_of($alrel_id).'" id="'.$alrel_id.'" dir="'.$dir.'">';
-		foreach($rels as $position=>$rel)
-		{
-			$uname = $rel->get_value('unique_name') ? ' to_uname="'.htmlspecialchars($rel->get_value('unique_name')).'"' : '';
-			$lines[] = $indent."\t".'<rel to_entity_id="'.$rel->id().'" '.$uname.'>';
-			if(isset($rels_info[$position]))
-			{
-				foreach($rels_info[$position] as $key=>$val)
-				{
-					if($key != 'type' && $key != 'entity_a' && $key != 'entity_b')
-						$lines[] = $indent."\t\t".'<attr name="'.$key.'">'.htmlspecialchars($val).'</attr>';
+		$xw->startElementWithAttrs('alrel', [
+			'name' => relationship_name_of($alrel_id),
+			'id' => $alrel_id,
+			'dir' => $dir
+		]);
+
+		foreach ($rels as $position => $rel) {
+
+			$xw->startElementWithAttrs('rel', [
+				'to_entity_id' => $rel->id(),
+				'to_uname' => ($rel->get_value('unique_name') ? htmlspecialchars($rel->get_value('unique_name')) : ''),
+			]);
+
+			if (isset($rels_info[$position])) {
+				foreach ($rels_info[$position] as $key => $val) {
+					if ($key != 'type' && $key != 'entity_a' && $key != 'entity_b') {
+						$xw->startElementWithAttrs('attr', [
+							'name' => $key
+						]);
+						$xw->addTextSafe($val);
+						$xw->endElement(); // attr
+					}
 				}
 			}
-			$lines[] = $indent."\t".'</rel>';
+			$xw->endElement(); // rel
 		}
-		$lines[] = $indent.'</alrel>';
-		return $lines;
+		$xw->endElement(); // alrel
 	}
 
 	function get_reason_username( $reason_id ) {


### PR DESCRIPTION
While exporting Athletics site content, I ran into a couple of issues:

- The performance was suboptimal: exports didn't finish. The `array_merges` in the `foreach` bogged down the export. [One way to solve this](https://github.com/kalessil/phpinspectionsea/blob/master/docs/performance.md#slow-array-function-used-in-loop) (but it didn't matter in the end)
 - Then I ran into some encoding issues of on strings. In a limited capacity, charset issues might exist today, too, but are mostly undetected since we weren't parsing the xml output.

**Resolution**
 - Switch to using the XMLWriter to generate XML
 - Validate & format the output before returning
 - Detect and resolve character set issues in the XML, which mostly seems to be the usual `ISO-8859-1` to `UTF-8` issues.

I've tested one WP migration with success.

We're emitting UTF8 XML now, to the best of my knowledge. Spot checks look good, but I'd appreciate a few more sets of eyes. The character encoding section specifically.