### PR TITLE
Reason Form Export for Gravity Forms

### DIFF
--- a/carl_util/basic/email_funcs.php
+++ b/carl_util/basic/email_funcs.php
@@ -18,12 +18,13 @@ require_once( CARL_UTIL_INC . 'basic/misc.php' );
  *
  * @param mixed $addresses can be any of the following: 1) a valid email address, 2) a username in the directory, 3) a comma-delimited combination of addresses and/or usernames, or 4) an array of addresses and/or usernames.
  * @param string $address_type can be 'mixed', 'email', or 'username'
- * @param string $return_type either 'string' or 'array'
+ * @param string $return_type 'string', 'array', 'errors'
  * @return mixed Comma separated email addresses or array of email addresses (when $return_type == 'array') 
  *
  **/
 function prettify_email_addresses($addresses, $address_type = 'mixed', $return_type = 'string')
 {
+	$errors = array();
 	if($address_type != 'mixed' && $address_type != 'email' && $address_type != 'username')
 	{
 		trigger_error('$address_type parameter ('.$address_type.') must be "mixed","email", or "username." Defaulting to "mixed".');
@@ -46,7 +47,10 @@ function prettify_email_addresses($addresses, $address_type = 'mixed', $return_t
 				{
 					if(empty($dir_value))
 					{
-						trigger_error('Username does not exist in directory service: '.$address.'. setting address to ' . WEBMASTER_EMAIL_ADDRESS . ' instead.');
+						$msg = 'Username does not exist in directory service: '.$address.'. setting address to ' . WEBMASTER_EMAIL_ADDRESS . ' instead.';
+						trigger_error($msg);
+						$errors[] = $msg;
+						
 						$address = WEBMASTER_EMAIL_ADDRESS;
 					}
 					else
@@ -64,7 +68,9 @@ function prettify_email_addresses($addresses, $address_type = 'mixed', $return_t
 			$num_results = preg_match( '/^([^<]+<)?([-.]|\w)+@([-.]|\w)+\.([-.]|\w)+>?$/i', $address );
 			if ($num_results <= 0)
 			{
-				trigger_error('The address ' . $address . ' is invalid - setting address to ' . WEBMASTER_EMAIL_ADDRESS . ' instead.');
+				$msg = 'The address ' . $address . ' is invalid - setting address to ' . WEBMASTER_EMAIL_ADDRESS . ' instead.';
+				trigger_error($msg);
+				$errors[] = $msg;
 				$pretty_address_array[] = WEBMASTER_EMAIL_ADDRESS;
 			}
 			else
@@ -76,6 +82,8 @@ function prettify_email_addresses($addresses, $address_type = 'mixed', $return_t
 	
 	if ($return_type == 'string') {
 		return implode(', ', $pretty_address_array);
+	} elseif($return_type == 'errors') {
+		return $errors;
 	} else {
 		return $pretty_address_array;
 	}

--- a/reason_4.0/lib/core/classes/admin/modules/newsletter/newsletter.php
+++ b/reason_4.0/lib/core/classes/admin/modules/newsletter/newsletter.php
@@ -717,6 +717,7 @@ class NewsletterExporter {
 			$output = '<h1>' . $data['info']['title'] . '</h1>';
 		if ($data['info']['intro'])
 			$output .= '<p>' . $data['info']['intro'] . '</p>';
+		$output = tidy($output);
 		if (!empty($data['pubs'])) 
 		{
 			$output .= "<h2>Recent News</h2>";
@@ -745,7 +746,7 @@ class NewsletterExporter {
 			}
 			$output .= "</ul>";
 		}
-		return tidy($output);
+		return $output;
 	}
 
 	/**
@@ -782,6 +783,7 @@ class NewsletterExporter {
 			$output = '<h1>' . $data['info']['title'] . '</h1>';
 		if ($data['info']['intro'])
 			$output .= '<p>' . $data['info']['intro'] . '</p>';
+		$output = tidy($output);
 		if (!empty($data['pubs'])) 
 		{
 			$output .= "<h2>Recent News</h2>";
@@ -811,7 +813,7 @@ class NewsletterExporter {
 			}
 			$output .= "</ul>";
 		}
-		return tidy($output);
+		return $output;
 	}	
 	
 	/**
@@ -851,6 +853,7 @@ class NewsletterExporter {
 			$output = '<h1>' . $data['info']['title'] . '</h1>';
 		if ($data['info']['intro'])
 			$output .= '<p>' . $data['info']['intro'] . '</p>';
+		$output = tidy($output);
 		if (!empty($data['pubs'])) 
 		{
 			$output .= "<h2>Recent News</h2>";
@@ -885,7 +888,7 @@ class NewsletterExporter {
 			}
 
 		}
-		return tidy($output);
+		return $output;
 	}
 	
 	/**
@@ -931,6 +934,7 @@ class NewsletterExporter {
 			$output = '<h1>' . $data['info']['title'] . '</h1>';
 		if ($data['info']['intro'])
 			$output .= '<p>' . $data['info']['intro'] . '</p>';
+		$output = tidy($output);
 		if (!empty($data['pubs'])) 
 		{
 			$output .= "<h2>Recent News</h2>";
@@ -969,7 +973,7 @@ class NewsletterExporter {
 			}
 
 		}
-		return tidy($output);
+		return $output;
 	}
 	
 	/**
@@ -1009,6 +1013,7 @@ class NewsletterExporter {
 			$output = '<h1>' . $data['info']['title'] . '</h1>';
 		if ($data['info']['intro'])
 			$output .= '<p>' . $data['info']['intro'] . '</p>';
+		$output = tidy($output);
 		if (!empty($data['pubs'])) 
 		{
 			$output .= "<h2>Recent News</h2>";
@@ -1050,7 +1055,7 @@ class NewsletterExporter {
 			}
 
 		}
-		return tidy($output);
+		return $output;
 	}
 }
 ?>

--- a/reason_4.0/lib/core/classes/thor_to_gravity.php
+++ b/reason_4.0/lib/core/classes/thor_to_gravity.php
@@ -8,11 +8,20 @@ require_once( INCLUDE_PATH . 'xml/xmlparser.php' );
 
 class reasonFormToGravityJson
 {
-	protected $messages = array();
+	protected $messages = array(
+		'Not yet implemented: notification emails',
+		'Not yet implemented: confirmation message',
+		'Not yet implemented: access restrictions',
+		'Not yet implemented: scheduling',
+		'Not yet implemented: entry limiting',
+		'Not yet implemented: prepopulation from ldap',
+		'Not yet implemented: payment forms or other custom thor forms',
+	);
 	function get_json($form)
 	{
 		$json_data = $this->get_initial_form_data();
 		$json_data['title'] = $form->get_value('name');
+		
 		if ($form->get_value('thor_content'))
 		{
 			$xml_object = new XMLParser($form->get_value('thor_content'));
@@ -26,7 +35,11 @@ class reasonFormToGravityJson
 		return json_encode(array(
 			0 => $json_data,
 			'version' => '2.4.5.10',
-		));
+		), JSON_PRETTY_PRINT);
+	}
+	function add_message($message)
+	{
+		$this->messages[] = $message;
 	}
 	function get_messages()
 	{
@@ -40,22 +53,6 @@ class reasonFormToGravityJson
 	{
 		return (!empty($xml_object->document->tagAttrs['submit'])) ? $xml_object->document->tagAttrs['submit'] : 'Submit';
 	}
-	protected function get_field_type_map()
-	{
-		return array(
-			'input' => 'text',
-			'date' => '',
-			'time' => '',
-			'textarea' => '',
-			'radiogroup' => '',
-			'checkboxgroup' => '',
-			'optiongroup' => 'select',
-			'hidden' => '',
-			'comment' => '',
-			'upload' => '',
-			'event_tickets' => '',
-		);
-	}
 	protected function get_field_data_from_parsed_xml($xml_object, $form)
 	{
 		$json_data = array();
@@ -65,13 +62,12 @@ class reasonFormToGravityJson
 			$method = 'get_json_data_for_' . $element->tagName;
 			if(method_exists($this, $method))
 			{
-				$json_data[] = $this->$method($element, $form);
+				$json_data[] = $this->$method($element, $form, ($index + 1) );
 				$index++;
 			}
 			else
 			{
-				// @todo include info about the not-included field
-				$this->messages[] = 'Field not included in data: ' . $this->get_label_for_element($element) . ' (' . $element->tagName . ')';
+				$this->add_message( 'Not able to include "' . $this->get_label_for_element($element) . '". Code has not yet been written to support the export of ' . $element->tagName . ' fields.' );
 			}
 		}
 		return $json_data;
@@ -178,9 +174,10 @@ class reasonFormToGravityJson
 	{
 		return (!empty($element->tagAttrs['label'])) ? $element->tagAttrs['label'] : '';
 	}
-	protected function get_json_data_for_input($element, $form)
+	protected function get_json_data_for_input($element, $form, $gravity_id)
 	{
 		$data = $this->get_initial_field_data();
+		$data['id'] = $gravity_id;
 		$data['type'] = 'text'; 
 		$data['label'] = $this->get_label_for_element($element);
 		$data['isRequired'] = (!empty($element->tagAttrs['required'])) ? true : false;
@@ -193,6 +190,232 @@ class reasonFormToGravityJson
 			if($element->tagAttrs['size'] > 40) $data['size'] = 'large'; // @todo: check on potential values in Gravity Forms
 			elseif($element->tagAttrs['size'] < 20) $data['size'] = 'small'; // @todo: check on potential values in Gravity Forms
 		}
+		$data = $this->modify_values_for_prefill($data, $element, $form);
+		return $data;
+	}
+	protected function get_json_data_for_textarea($element, $form, $gravity_id)
+	{
+		$data = $this->get_initial_field_data();
+		$data['id'] = $gravity_id;
+		$data['type'] = 'textarea'; 
+		$data['label'] = $this->get_label_for_element($element);
+		$data['isRequired'] = (!empty($element->tagAttrs['required'])) ? true : false;
+		$data['maxLength'] = (!empty($element->tagAttrs['maxlength'])) ? $element->tagAttrs['maxlength'] : '';
+		$data['defaultValue'] = (!empty($element->tagAttrs['value'])) ? $element->tagAttrs['value'] : '';
+
+		$data['size'] = 'medium';	
+		if(!empty($element->tagAttrs['rows']) || !empty($element->tagAttrs['cols']))
+		{
+			$this->add_message('Did not set rows and columns on "' . $data['label'] . '". This functionality does not exist in Gravity Forms.');
+		}
+		$data = $this->modify_values_for_prefill($data, $element, $form);
+		return $data;
+	}
+	protected function get_json_data_for_radiogroup($element, $form, $gravity_id)
+	{
+		$data = $this->get_initial_field_data();
+		$data['id'] = $gravity_id;
+		$data['type'] = 'radio';
+		$data['label'] = $this->get_label_for_element($element);
+		$data['isRequired'] = (!empty($element->tagAttrs['required'])) ? true : false;
+		$data['defaultValue'] = (!empty($element->tagAttrs['value'])) ? $element->tagAttrs['value'] : '';
+		$choices = array();
+		foreach($element->tagChildren as $child)
+		{
+			$value = (!empty($child->tagAttrs['value'])) ? $child->tagAttrs['value'] : '';
+			$choices[] = array(
+				'text' => $value,
+				'value' => $value,
+				'isSelected' => (!empty($child->tagAttrs['selected'])) ? true : false,
+				'price' => '',
+			);
+		}
+		$data['choices'] = $choices;
+		$data = $this->modify_values_for_prefill($data, $element, $form, $gravity_id);
+		return $data;
+	}
+	protected function get_json_data_for_optiongroup($element, $form, $gravity_id)
+	{
+		$data = $this->get_initial_field_data();
+		$data['id'] = $gravity_id;
+		$data['type'] = 'select';
+		$data['label'] = $this->get_label_for_element($element);
+		$data['isRequired'] = (!empty($element->tagAttrs['required'])) ? true : false;
+		$data['defaultValue'] = '';
+		$choices = array();
+		foreach($element->tagChildren as $child)
+		{
+			$value = (!empty($child->tagAttrs['value'])) ? $child->tagAttrs['value'] : '';
+			$choices[] = array(
+				'text' => $value,
+				'value' => $value,
+				'isSelected' => (!empty($child->tagAttrs['selected'])) ? true : false,
+				'price' => '',
+			);
+		}
+		$data['choices'] = $choices;
+		$data = $this->modify_values_for_prefill($data, $element, $form);
+		return $data;
+	}
+	protected function get_json_data_for_checkboxgroup($element, $form, $gravity_id) {
+		$data = $this->get_initial_field_data();
+		$data['id'] = $gravity_id;
+		$data['type'] = 'checkbox';
+		$data['label'] = $this->get_label_for_element($element);
+		$data['isRequired'] = (!empty($element->tagAttrs['required'])) ? true : false;
+		$data['defaultValue'] = '';
+		$choices = array();
+		$inputs = array();
+		$index = 1;
+		foreach($element->tagChildren as $child)
+		{
+			$value = (!empty($child->tagAttrs['value'])) ? $child->tagAttrs['value'] : '';
+			$choices[] = array(
+				'text' => $value,
+				'value' => $value,
+				'isSelected' => (!empty($child->tagAttrs['selected'])) ? true : false,
+				'price' => '',
+			);
+			$inputs[] = array(
+				'id' => $gravity_id . '.' . $index,
+				'label' => $value,
+				'name' => '',
+			);
+			$index++;
+		}
+		$data['choices'] = $choices;
+		$data['inputs'] = $inputs;
+		$data = $this->modify_values_for_prefill($data, $element, $form);
+		return $data;
+	}
+	protected function standardize_upload_restrictions($stuff)
+	{
+		$rv = Array();
+		$explodedStuff = explode(",",$stuff);
+		foreach ($explodedStuff as $stuffChunk) {
+			$rv[] = strtolower(trim($stuffChunk));
+		}
+		return $rv;
+	}
+	protected function get_json_data_for_upload($element, $form, $gravity_id)
+	{
+		$data = $this->get_initial_field_data();
+		$data['id'] = $gravity_id;
+		$data['type'] = 'fileupload'; 
+		$data['label'] = $this->get_label_for_element($element);
+		$data['isRequired'] = (!empty($element->tagAttrs['required'])) ? true : false;
+		if (!empty($element->tagAttrs['restrict_extensions'])) {
+			$data['allowedExtensions'] = $this->standardize_upload_restrictions($element->tagAttrs['restrict_extensions']);
+		}
+
+		if (!empty($element->tagAttrs['restrict_types'])) {
+			$this->add_message('Unable to restrict mime types on "' . $data['label'] . '". This restriction is not supported in Gravity forms.');
+		}
+		if (!empty($element->tagAttrs['restrict_maxsize'])) {
+			// @todo figure out the format of this. "1MB" seems to resolve to "1" but need to figure out more
+			$this->add_message('Unable to restrict maximum size on "' . $data['label'] . '". Export not yet supported.');
+		}
+		$data = $this->modify_values_for_prefill($data, $element, $form);
+		return $data;
+	}
+	protected function get_json_data_for_hidden($element, $form, $gravity_id)
+	{
+		$data = $this->get_initial_field_data();
+		$data['id'] = $gravity_id;
+		$data['type'] = 'hidden'; 
+		$data['label'] = $this->get_label_for_element($element);
+		$data['isRequired'] = (!empty($element->tagAttrs['required'])) ? true : false;
+		$data['defaultValue'] = (!empty($element->tagAttrs['value'])) ? $element->tagAttrs['value'] : '';
+		$data = $this->modify_values_for_prefill($data, $element, $form);
+		return $data;
+	}
+	protected function get_json_data_for_comment($element, $form, $gravity_id)
+	{
+		$data = $this->get_initial_field_data();
+		$data['id'] = $gravity_id;
+		$data['type'] = 'html'; 
+		$data['label'] = $this->get_label_for_element($element);
+		$data['content'] = $element->tagData;
+		$data = $this->modify_values_for_prefill($data, $element, $form);
+		return $data;
+	}
+	protected function does_form_prefill($form)
+	{
+		switch($form->get_value('magic_string_autofill'))
+		{
+			case 'editable':
+			case 'not_editable':
+				return $form->get_value('magic_string_autofill');
+			default:
+				return false;
+		}
+	}
+	protected function modify_values_for_prefill($data, $element, $form)
+	{
+		if($this->does_form_prefill($form))
+		{
+			$label = $this->get_label_for_element($element);
+			$match_label = strtolower($label);
+			$match_label = trim($match_label);
+			$match_label = trim($match_label, ':');
+			$match_label = trim($match_label);
+			$match_label = str_replace(' ', '_', $match_label);
+			$function = 'modify_json_data_for_prefill_' . $match_label;
+			if(method_exists($this, $function))
+			{
+				$data = $this->$function($data, $element, $form);
+			}
+		}
+		return $data;
+	}
+	protected function modify_json_data_for_prefill_your_name($data, $element, $form)
+	{
+		$data['allowsPrepopulate'] = true;
+		$data['inputName'] = 'fullName';
+		return $data;
+	}
+	protected function modify_json_data_for_prefill_your_full_name($data, $element, $form)
+	{
+		$data['allowsPrepopulate'] = true;
+		$data['inputName'] = 'fullName';
+		return $data;
+	}
+	protected function modify_json_data_for_prefill_your_first_name($data, $element, $form)
+	{
+		$data['allowsPrepopulate'] = true;
+		$data['inputName'] = 'firstName';
+		return $data;
+	}
+	protected function modify_json_data_for_prefill_your_last_name($data, $element, $form)
+	{
+		$data['allowsPrepopulate'] = true;
+		$data['inputName'] = 'lastName';
+		return $data;
+	}
+	protected function modify_json_data_for_prefill_your_department($data, $element, $form)
+	{
+		$data['allowsPrepopulate'] = true;
+		$data['inputName'] = 'department';
+		return $data;
+	}
+	protected function modify_json_data_for_prefill_your_email($data, $element, $form)
+	{
+		$this->add_message('Unable to set prefill for "' . $this->get_label_for_element($element) . '". Code not yet written.');
+		return $data;
+	}
+	protected function modify_json_data_for_prefill_your_home_phone($data, $element, $form)
+	{
+		$this->add_message('Unable to set prefill for "' . $this->get_label_for_element($element) . '". Code not yet written.');
+		return $data;
+	}
+	protected function modify_json_data_for_prefill_your_work_phone($data, $element, $form)
+	{
+		$this->add_message('Unable to set prefill for "' . $this->get_label_for_element($element) . '". Code not yet written.');
+		return $data;
+	}
+	protected function modify_json_data_for_prefill_your_title($data, $element, $form)
+	{
+		$this->add_message('Unable to set prefill for "' . $this->get_label_for_element($element) . '". This prefill is not currently supported in Gravity Forms.');
 		return $data;
 	}
 }

--- a/reason_4.0/lib/core/classes/thor_to_gravity.php
+++ b/reason_4.0/lib/core/classes/thor_to_gravity.php
@@ -195,6 +195,12 @@ class reasonFormToGravityJson
 				'enableAttachments' => false,
 			));
 		}
+		$errors = prettify_email_addresses($form->get_value('email_of_recipient'), 'mixed', 'errors');
+		$error_count = count($errors);
+		if($error_count)
+		{
+			$this->add_message('Recipient email(s) included ' . $error_count . ' username(s) that could not be resolved to an email address. These usernames have been replaced with the webmaster email address. Please resolve this in Gravity Forms.');
+		}
 		return $data;
 	}
 	protected function add_confirmations($data, $form)

--- a/reason_4.0/lib/core/classes/thor_to_gravity.php
+++ b/reason_4.0/lib/core/classes/thor_to_gravity.php
@@ -1,0 +1,198 @@
+<?php
+/**
+ * @package reason
+ */
+
+include_once('paths.php');
+require_once( INCLUDE_PATH . 'xml/xmlparser.php' );
+
+class reasonFormToGravityJson
+{
+	protected $messages = array();
+	function get_json($form)
+	{
+		$json_data = $this->get_initial_form_data();
+		$json_data['title'] = $form->get_value('name');
+		if ($form->get_value('thor_content'))
+		{
+			$xml_object = new XMLParser($form->get_value('thor_content'));
+			$xml_object->Parse();	
+			if($xml_object)
+			{
+				$json_data['button']['text'] = $this->get_button_label_from_parsed_xml($xml_object, $form);
+				$json_data['fields'] = $this->get_field_data_from_parsed_xml($xml_object, $form);
+			}
+		}
+		return json_encode(array(
+			0 => $json_data,
+			'version' => '2.4.5.10',
+		));
+	}
+	function get_messages()
+	{
+		return $this->messages;
+	}
+	function clear_messages()
+	{
+		$this->messages = array();	
+	}
+	protected function get_button_label_from_parsed_xml($xml_object)
+	{
+		return (!empty($xml_object->document->tagAttrs['submit'])) ? $xml_object->document->tagAttrs['submit'] : 'Submit';
+	}
+	protected function get_field_type_map()
+	{
+		return array(
+			'input' => 'text',
+			'date' => '',
+			'time' => '',
+			'textarea' => '',
+			'radiogroup' => '',
+			'checkboxgroup' => '',
+			'optiongroup' => 'select',
+			'hidden' => '',
+			'comment' => '',
+			'upload' => '',
+			'event_tickets' => '',
+		);
+	}
+	protected function get_field_data_from_parsed_xml($xml_object, $form)
+	{
+		$json_data = array();
+		$index = 0;
+		foreach ($xml_object->document->tagChildren as $element)
+		{
+			$method = 'get_json_data_for_' . $element->tagName;
+			if(method_exists($this, $method))
+			{
+				$json_data[] = $this->$method($element, $form);
+				$index++;
+			}
+			else
+			{
+				// @todo include info about the not-included field
+				$this->messages[] = 'Field not included in data: ' . $this->get_label_for_element($element) . ' (' . $element->tagName . ')';
+			}
+		}
+		return $json_data;
+	}
+	protected function get_initial_form_data()
+	{
+		return array(
+			'title' =>  '',
+			'description' => '',
+			'labelPlacement' => 'top_label',
+			'descriptionPlacement' => 'below',
+			'button' => array(
+				'type' => 'text',
+				'text' => 'Submit',
+				'imageUrl' => '',
+			),
+			'version' => '2.4.0.1',
+			'id' => 1, // Not sure if this matters
+			'useCurrentUserAsAuthor' => true,
+			'postContentTemplateEnabled' => false,
+			'postTitleTemplateEnabled' => false,
+			'postTitleTemplate' => '',
+			'postContentTemplate' => '',
+			'lastPageButton' => null,
+			'pagination' => null,
+			'firstPageCssClass' => null,
+			'subLabelPlacement' => 'below',
+			'cssClass' => '',
+			'enableHoneypot' => true,
+			'enableAnimation' => false,
+			'save' => array(
+				'enabled' => false,
+				'button' => array(
+					'type' => 'link',
+					'text' => 'Save and Continue Later',
+				),
+			),
+			'limitEntries' => false,
+			'limitEntriesCount' => '',
+			'limitEntriesPeriod' => '',
+			'limitEntriesMessage' => '',
+			'scheduleForm' => false,
+			'scheduleStart' => '',
+			'scheduleStartHour' => '',
+			'scheduleStartMinute' => '',
+			'scheduleStartAmpm' => '',
+			'scheduleEnd' => '',
+			'scheduleEndHour' => '',
+			'scheduleEndMinute' => '',
+			'scheduleEndAmpm' => '',
+			'schedulePendingMessage' => '',
+			'scheduleMessage' => '',
+			'requireLogin' => false,
+			'requireLoginMessage' => '',
+			'nextFieldId' => 21, // need to figure out what is is about
+			'confirmations' => array(),
+			'notifications' => array(),
+		);
+	}
+	protected function get_initial_field_data()
+	{
+		return array(
+			'type' => '',
+			'id' => 0,
+			'label' => '',
+			'adminLabel' => '',
+			'isRequired' => false,
+			'size' => '',
+			'errorMessage' => '',
+			'visibility' => 'visible',
+			'inputs' => null,
+			'formId' => 1,
+			'description' => '',
+			'allowsPrepopulate' => false,
+			'inputMask' => false,
+			'inputMaskValue' => '',
+			'maxLength' => '',
+			'inputType' => '',
+			'labelPlacement' => '',
+			'descriptionPlacement' => '',
+			'subLabelPlacement' => '',
+			'placeholder' => '',
+			'cssClass' => '',
+			'inputName' => '',
+			'noDuplicates' => false,
+			'defaultValue' => '',
+			'choices' => '',
+			'conditionalLogic' => '',
+			'productField' => '',
+			'enablePasswordInput' => '',
+			'multipleFiles' => false,
+			'maxFiles' => '',
+			'calculationFormula' => '',
+			'calculationRounding' => '',
+			'enableCalculation' => '',
+			'disableQuantity' => false,
+			'displayAllCategories' => false,
+			'useRichTextEditor' => false,
+			'fields' => '',
+			'displayOnly' => '',
+		);
+	}
+	protected function get_label_for_element($element)
+	{
+		return (!empty($element->tagAttrs['label'])) ? $element->tagAttrs['label'] : '';
+	}
+	protected function get_json_data_for_input($element, $form)
+	{
+		$data = $this->get_initial_field_data();
+		$data['type'] = 'text'; 
+		$data['label'] = $this->get_label_for_element($element);
+		$data['isRequired'] = (!empty($element->tagAttrs['required'])) ? true : false;
+		$data['maxLength'] = (!empty($element->tagAttrs['maxlength'])) ? $element->tagAttrs['maxlength'] : '';
+		$data['defaultValue'] = (!empty($element->tagAttrs['value'])) ? $element->tagAttrs['value'] : '';
+
+		$data['size'] = 'medium';		
+		if(!empty($element->tagAttrs['size']))
+		{
+			if($element->tagAttrs['size'] > 40) $data['size'] = 'large'; // @todo: check on potential values in Gravity Forms
+			elseif($element->tagAttrs['size'] < 20) $data['size'] = 'small'; // @todo: check on potential values in Gravity Forms
+		}
+		return $data;
+	}
+}

--- a/reason_4.0/lib/core/classes/thor_to_gravity.php
+++ b/reason_4.0/lib/core/classes/thor_to_gravity.php
@@ -339,6 +339,52 @@ class reasonFormToGravityJson
 		$data = $this->modify_values_for_prefill($data, $element, $form);
 		return $data;
 	}
+	protected function get_json_data_for_date($element, $form, $gravity_id)
+	{
+		$data = $this->get_initial_field_data();
+		$data['id'] = $gravity_id;
+		$data['type'] = 'date'; 
+		$data['dateType'] = 'datepicker';
+		$data['calendarIconType'] = 'calendar';
+		$data['label'] = $this->get_label_for_element($element);
+		$data['isRequired'] = (!empty($element->tagAttrs['required'])) ? true : false;
+		$data['defaultValue'] = (!empty($element->tagAttrs['value'])) ? $element->tagAttrs['value'] : '';
+		$data = $this->modify_values_for_prefill($data, $element, $form);
+		if(!empty($element->tagAttrs['date_field_time_enabled']))
+		{
+			$this->add_message('Gravity forms does not support a shared date/time field. "'. $data['label'] . '" added as a date field without time component.');
+		}
+		return $data;
+	}
+	protected function get_json_data_for_time($element, $form, $gravity_id)
+	{
+		$data = $this->get_initial_field_data();
+		$data['id'] = $gravity_id;
+		$data['type'] = 'time'; 
+		$data['timeFormat'] = '12';
+		$data['label'] = $this->get_label_for_element($element);
+		$data['isRequired'] = (!empty($element->tagAttrs['required'])) ? true : false;
+		$data['defaultValue'] = (!empty($element->tagAttrs['value'])) ? $element->tagAttrs['value'] : '';
+		$data['inputs'] = array(
+			array(
+				'id' => $gravity_id.'.1',
+				'label' => 'HH',
+				'name' => '',
+			),
+			array(
+				'id' => $gravity_id.'.2',
+				'label' => 'MM',
+				'name' => '',
+			),
+			array(
+				'id' => $gravity_id.'.3',
+				'label' => 'AM/PM',
+				'name' => '',
+			),
+		);
+		$data = $this->modify_values_for_prefill($data, $element, $form);
+		return $data;
+	}
 	protected function does_form_prefill($form)
 	{
 		switch($form->get_value('magic_string_autofill'))
@@ -400,17 +446,27 @@ class reasonFormToGravityJson
 	}
 	protected function modify_json_data_for_prefill_your_email($data, $element, $form)
 	{
-		$this->add_message('Unable to set prefill for "' . $this->get_label_for_element($element) . '". Code not yet written.');
+		$data['type'] = 'email';
+		$data['allowsPrepopulate'] = true;
+		$data['inputName'] = 'email';
 		return $data;
 	}
 	protected function modify_json_data_for_prefill_your_home_phone($data, $element, $form)
 	{
-		$this->add_message('Unable to set prefill for "' . $this->get_label_for_element($element) . '". Code not yet written.');
+		$data['type'] = 'phone';
+		$data['allowsPrepopulate'] = true;
+		$data['inputName'] = 'phone';
+		$data['phoneFormat'] = 'international';
+		$this->add_message('"Your Home Phone" given generic "phone" prefill due to limitations in Gravity forms.');
 		return $data;
 	}
 	protected function modify_json_data_for_prefill_your_work_phone($data, $element, $form)
 	{
-		$this->add_message('Unable to set prefill for "' . $this->get_label_for_element($element) . '". Code not yet written.');
+		$data['type'] = 'phone';
+		$data['allowsPrepopulate'] = true;
+		$data['inputName'] = 'phone';
+		$data['phoneFormat'] = 'international';
+		$this->add_message('"Your Work Phone" given generic "phone" prefill due to limitations in Gravity forms.');
 		return $data;
 	}
 	protected function modify_json_data_for_prefill_your_title($data, $element, $form)

--- a/reason_4.0/lib/core/classes/thor_to_gravity.php
+++ b/reason_4.0/lib/core/classes/thor_to_gravity.php
@@ -31,6 +31,7 @@ class reasonFormToGravityJson
 		$json_data = $this->add_access_restrictions($json_data, $form);
 		$json_data = $this->add_scheduling($json_data, $form);
 		$json_data = $this->add_submission_limit($json_data, $form);
+		$json_data = $this->add_editable_rules($json_data, $form);
 		$json_data = $this->modify_custom_form($json_data, $form);
 		return json_encode(array(
 			0 => $json_data,
@@ -217,6 +218,10 @@ class reasonFormToGravityJson
 			'disableAutoformat' => false,
 			'conditionalLogic' => array(),
 		));
+		if($form->get_value('email_submitter'))
+		{
+			$this->add_message('This form is set up to email the submitter. Export code not yet written to transfer this automatically, so it will need to be manually configured in Gravity Forms.');
+		}
 		return $data;
 	}
 	protected function add_access_restrictions($data, $form)
@@ -225,7 +230,7 @@ class reasonFormToGravityJson
 		if(count($groups) > 0)
 		{
 			$data['requireLogin'] = true;
-			$this->add_message('Set form to require login. Anyone who can log in will be able to access this form unless more specific access control is manually applied in WordPress on the page the form is placed on.');
+			$this->add_message('This Reason form is set to limit access to a group. Note that the Gravity Forms import process only supports broad access control -- anyone who can log in will be able to access this form until more specific access control is manually applied in WordPress on the page the form is placed on.');
 		}
 		return $data;
 	}
@@ -262,7 +267,23 @@ class reasonFormToGravityJson
 	{
 		if($form->get_value('thor_view'))
 		{
-			$this->add_message('This form has custom behavior. Code not yet written to automatically transfer custom behavior to Gravity Forms.');
+			$this->add_message('This form has custom behavior. Export code not yet written to automatically transfer custom behavior to Gravity Forms.');
+		}
+		return $data;
+	}
+	protected function add_editable_rules($data, $form)
+	{
+		if($form->get_value('is_editable') == 'yes')
+		{
+			$this->add_message('This form allows submitters to come back and edit previously submitted entries. This export does not yet support automatically transferring that functionality to Gravity Forms, so it will need to be manually configured in WordPress.');
+			if($form->get_value('allow_multiple') == 'yes')
+			{
+				// stub for when we add support for this
+			}
+			if($form->get_value('email_link') == 'yes')
+			{
+				// stub for when we add support for this
+			}
 		}
 		return $data;
 	}

--- a/reason_4.0/lib/core/config/entity_delegates/config.php
+++ b/reason_4.0/lib/core/config/entity_delegates/config.php
@@ -67,6 +67,11 @@ $entity_delegates_config_setting = array(
 			'entity_delegates/media_work.php',
 		),
 	),
+	'form' => array(
+		'append' => array(
+			'entity_delegates/form.php',
+		),
+	),
 );
 
 

--- a/reason_4.0/lib/core/content_previewers/form.php
+++ b/reason_4.0/lib/core/content_previewers/form.php
@@ -19,7 +19,15 @@
 			
 			$data = $this->_entity->get_gravity_forms_json_and_messages();
 			$this->show_item_default( 'gravity_forms_json', '<textarea>'.htmlspecialchars($data['json']).'</textarea>' );
-			$this->show_item_default( 'gravity_forms_error_messages', implode( '<br />', $data['messages'] ) );
+			if(!empty($data['messages']))
+			{
+				$messages = '<ul><li>' . implode( '</li><li>', $data['messages'] ) . '</li></ul>';
+			}
+			else
+			{
+				$messages = 'No messages. Import should be clean!';
+			}
+			$this->show_item_default( 'gravity_forms_export_messages', $messages );
 		}
 
 		function show_item_thor_content( $field , $value )

--- a/reason_4.0/lib/core/content_previewers/form.php
+++ b/reason_4.0/lib/core/content_previewers/form.php
@@ -13,9 +13,19 @@
 	 */
 	class formPreviewer extends default_previewer
 	{
+		function display_entity()
+		{
+			$this->show_all_values( $this->_entity->get_values() );
+			
+			$data = $this->_entity->get_gravity_forms_json_and_messages();
+			$this->show_item_default( 'gravity_forms_json', '<textarea>'.htmlspecialchars($data['json']).'</textarea>' );
+			$this->show_item_default( 'gravity_forms_error_messages', implode( '<br />', $data['messages'] ) );
+		}
+
 		function show_item_thor_content( $field , $value )
 		{
 			$this->show_item_default( $field, htmlspecialchars($value) );
 		}
+		
 	}
 ?>

--- a/reason_4.0/lib/core/entity_delegates/form.php
+++ b/reason_4.0/lib/core/entity_delegates/form.php
@@ -1,0 +1,26 @@
+<?php
+
+reason_include_once( 'entity_delegates/abstract.php' );
+reason_include_once('classes/thor_to_gravity.php');
+
+$GLOBALS['entity_delegates']['entity_delegates/form.php'] = 'formDelegate';
+
+class formDelegate extends entityDelegate
+{
+	function get_gravity_forms_json_and_messages()
+	{
+		$transformer = new reasonFormToGravityJson();
+		return array(
+			'json' => $transformer->get_json($this->entity),
+			'messages' => $transformer->get_messages(),
+		);
+	}
+	function get_export_generated_data()
+	{
+		$ret = array();
+		$gravity_data = $this->get_gravity_forms_json_and_messages();
+		$ret['gravity_forms_json'] = $gravity_data['json'];
+		$ret['gravity_forms_messages'] = implode("\n", $gravity_data['messages']);
+		return $ret;
+	}
+}


### PR DESCRIPTION
An initial export of Reason forms in a format that Gravity Forms can import.

To check it out, preview any form. At the bottom of the preview there should be two new elements: a json export and messages about any warnings or errors encountered in generating the export.

To test an import into Gravity Forms, copy and paste the json into a file, then go to import/export -> Import under Gravity Forms in WP and upload the file.

Both the preview and the messages are also included in any XML or CSV exports as well.

Two future enhancements that would make things simpler would be adding the ability to export the json as a file, and to build json ingestion into our migration scripts. But I think this is useful already as a major time saver.