### PR TITLE
Fixed bug for substr'ing a utf-8 string that may have special chars

### DIFF
--- a/reason_4.0/lib/core/minisite_templates/modules/course_list.php
+++ b/reason_4.0/lib/core/minisite_templates/modules/course_list.php
@@ -451,7 +451,7 @@ class CourseListModule extends DefaultMinisiteModule
 			foreach ($fac_data as $id => $name)
 			{
 				list($last, $first) = explode(', ', $name);
-				$faculty[$id] = $first[0].'. '.$last;
+				$faculty[$id] = mb_substr($first, 0, 1).'. '.$last;
 			}
 			$details[] = join(', ', $faculty);	
 		}


### PR DESCRIPTION
When displaying a course the php code grabs the first letter of the first name. However when it's a multibyte special char simply doing a `$first[0];` or `substr($first, 0, 1);` [results in a "�" displaying](https://apps.carleton.edu/campus/registrar/catalog/current/course-details/?subject=CCST&number=275).  To deal with [multibyte sub stringing](https://stackoverflow.com/questions/6257818/using-phps-substr-with-special-characters-at-the-end-results-in-question-mark) we should use `mb_substr` instead.
